### PR TITLE
refactor(iam-policies): Remove redundancy in a statements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 4.16"
     }
     awscc = {
-      source = "hashicorp/awscc"
+      source  = "hashicorp/awscc"
       version = "0.71.0"
     }
   }

--- a/resource.tf
+++ b/resource.tf
@@ -97,13 +97,6 @@ resource "aws_iam_policy" "intents_operator_policy" {
             "iam:DeleteRolePermissionsBoundary"
           ]
           Resource = "*"
-        },
-        {
-          Effect = "Allow"
-          Action = [
-
-          ]
-          Resource = "*"
         }
       ]
   })
@@ -121,24 +114,23 @@ resource "aws_iam_policy" "credentials_operator_policy" {
         {
           Effect = "Allow"
           Action = [
+            "ec2:DescribeInstances",
+            "eks:DescribeCluster",
+            "iam:DeletePolicy",
+            "iam:DeletePolicyVersion",
+            "iam:DeleteRole",
+            "iam:DetachRolePolicy",
             "iam:GetPolicy",
             "iam:GetRole",
             "iam:ListAttachedRolePolicies",
             "iam:ListEntitiesForPolicy",
-            "iam:ListPolicyVersions"
+            "iam:ListPolicyVersions",
+            "iam:TagPolicy",
+            "iam:TagRole",
+            "iam:UntagPolicy",
+            "iam:UntagRole"
           ]
           Resource = "*"
-        },
-        {
-          Effect = "Deny"
-          Action = [
-            "iam:*"
-          ]
-          Resource = [
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.eks_cluster_name}-otterize-intents-operator",
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.eks_cluster_name}-otterize-credentials-operator",
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.eks_cluster_name}-limit-iam-permission-boundary"
-          ]
         },
         {
           Effect = "Allow"
@@ -155,31 +147,20 @@ resource "aws_iam_policy" "credentials_operator_policy" {
           }
         },
         {
-          Effect = "Allow"
+          Effect = "Deny"
           Action = [
-            "iam:DeletePolicy",
-            "iam:DeletePolicyVersion",
-            "iam:DeleteRole",
-            "iam:DetachRolePolicy",
-            "iam:TagRole",
-            "iam:TagPolicy",
-            "iam:UntagRole",
-            "iam:UntagPolicy",
+            "iam:*"
           ]
-          Resource = "*"
+          Resource = [
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.eks_cluster_name}-otterize-intents-operator",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.eks_cluster_name}-otterize-credentials-operator",
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.eks_cluster_name}-limit-iam-permission-boundary"
+          ]
         },
         {
           Effect = "Deny"
           Action = [
             "iam:DeleteRolePermissionsBoundary"
-          ]
-          Resource = "*"
-        },
-        {
-          Effect = "Allow"
-          Action = [
-            "ec2:DescribeInstances",
-            "eks:DescribeCluster"
           ]
           Resource = "*"
         }

--- a/resource.tf
+++ b/resource.tf
@@ -62,11 +62,21 @@ resource "aws_iam_policy" "intents_operator_policy" {
         {
           Effect = "Allow"
           Action = [
+            "ec2:DescribeInstances",
+            "eks:DescribeCluster",
+            "iam:AttachRolePolicy",
+            "iam:CreatePolicy",
+            "iam:CreatePolicyVersion",
+            "iam:DeletePolicy",
+            "iam:DeletePolicyVersion",
+            "iam:DetachRolePolicy",
             "iam:GetPolicy",
             "iam:GetRole",
             "iam:ListAttachedRolePolicies",
             "iam:ListEntitiesForPolicy",
-            "iam:ListPolicyVersions"
+            "iam:ListPolicyVersions",
+            "iam:TagPolicy",
+            "iam:UntagPolicy"
           ]
           Resource = "*"
         },
@@ -84,16 +94,6 @@ resource "aws_iam_policy" "intents_operator_policy" {
         {
           Effect = "Deny"
           Action = [
-            "iam:CreatePolicyVersion",
-            "iam:DeletePolicyVersion",
-            "iam:DetachRolePolicy",
-            "iam:SetDefaultPolicyVersion"
-          ]
-          Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.eks_cluster_name}-limit-iam-permission-boundary"
-        },
-        {
-          Effect = "Deny"
-          Action = [
             "iam:DeleteRolePermissionsBoundary"
           ]
           Resource = "*"
@@ -101,16 +101,7 @@ resource "aws_iam_policy" "intents_operator_policy" {
         {
           Effect = "Allow"
           Action = [
-            "iam:AttachRolePolicy",
-            "iam:CreatePolicy",
-            "iam:CreatePolicyVersion",
-            "iam:DeletePolicy",
-            "iam:DeletePolicyVersion",
-            "iam:TagPolicy",
-            "iam:UntagPolicy",
-            "iam:DetachRolePolicy",
-            "ec2:DescribeInstances",
-            "eks:DescribeCluster"
+
           ]
           Resource = "*"
         }


### PR DESCRIPTION
### Description

Refined IAM policies statements to make it more clear: remove redundant statement from intent's policy. Concatenate policies and sort it ascending.

### Testing

I run `terraform init`+`terraform validate`+`terraform plan` and it generated valid policies. But I never applied it on my environments.